### PR TITLE
docs: add deprecation notice for app store migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Docker image for [AvNav](https://www.wellenvogel.net/software/avnav/docs/), an open-source marine navigation software for Raspberry Pi.
 
+> **Note:** As of 2025-10-28, the HaLOS Runtipi Marine App Store now uses the [free-x/avnav-docker](https://github.com/free-x/avnav-docker) image (`xfreex/avnav-daily`) instead of this custom build. The free-x image includes additional plugins (mapproxy, o-charts) and is actively maintained by the community. This repository is kept for reference and alternative deployment scenarios.
+
 ## Overview
 
 AvNav is a navigation software that turns your Raspberry Pi into a powerful marine navigation computer. This Docker image packages AvNav for easy deployment and integration with other marine software like Signal K.


### PR DESCRIPTION
## Summary

This PR adds a deprecation notice to the README explaining that the HaLOS Runtipi Marine App Store now uses the free-x/avnav-docker image instead of this custom build.

## Changes

- Add prominent note at the top of README
- Explain migration to `xfreex/avnav-daily` image
- Highlight benefits of the free-x image
- Clarify that this repository remains for reference

## Context

The app store has been updated to use the [free-x/avnav-docker](https://github.com/free-x/avnav-docker) image because it provides:

- **Additional plugins**: mapproxy and o-charts support built-in
- **Community maintenance**: Actively maintained by the community
- **Official repository**: Uses oss.boating APT repository
- **Better hardware support**: Host networking and proper device access

## Post-Merge

After this PR is merged, the repository can be archived to indicate it is no longer actively maintained but kept for reference and alternative deployment scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)